### PR TITLE
integration with tofu-ls binary

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -16,8 +16,8 @@ custom:
     type: enum
     enumOptions:
       - vscode-opentofu
-      - opentofu-ls
-      - terraform-schema
+      - tofu-ls
+      - opentofu-schema
       - hcl-lang
   - key: Issue
     label: Issue/PR Number

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -5,6 +5,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as tar from 'tar';
+
 import axios from 'axios';
 
 async function fileFromUrl(url: string): Promise<Buffer> {
@@ -70,6 +72,10 @@ function getExtensionInfo(): ExtensionInfo {
   };
 }
 
+function capitalize(s: string) {
+  return String(s[0]).toUpperCase() + String(s).slice(1);
+}
+
 async function downloadLanguageServer(platform: string, architecture: string, extInfo: ExtensionInfo) {
   const cwd = path.resolve(__dirname);
 
@@ -79,11 +85,8 @@ async function downloadLanguageServer(platform: string, architecture: string, ex
   const buildDir = path.basename(cwd);
   const repoDir = cwd.replace(buildDir, '');
   const installPath = path.join(repoDir, 'bin');
-  const filename = os === 'windows' ? 'opentofu-ls.exe' : 'opentofu-ls';
-  const packageName =
-    os === 'windows'
-      ? `opentofu-ls_${extInfo.languageServerVersion}_${os}_${arch}.exe`
-      : `opentofu-ls_${extInfo.languageServerVersion}_${os}_${arch}`;
+  const filename = os === 'windows' ? 'tofu-ls.exe' : 'tofu-ls';
+  const packageName = os === 'windows' ? `tofu-ls_${capitalize(os)}_${arch}.exe` : `tofu-ls_${capitalize(os)}_${arch}`;
   const filePath = path.join(installPath, filename);
   if (fs.existsSync(filePath)) {
     if (process.env.downloader_log === 'true') {
@@ -147,17 +150,22 @@ async function downloadSyntax(info: ExtensionInfo) {
 
 export async function fetchVersion(release: Release): Promise<void> {
   validateRelease(release);
-  await downloadBinary(release);
+  await downloadTarGz(release);
 }
 
-async function downloadBinary(release: Release) {
-  const url = `https://github.com/${release.repository}/releases/download/v${release.version}/${release.package}`;
+function untarFiles(path: string) {
+  tar.extract({
+    f: path,
+    C: 'bin',
+  });
+}
+
+async function downloadTarGz(release: Release) {
+  const url = `https://github.com/${release.repository}/releases/download/v${release.version}/${release.package}.tar.gz`;
 
   const fpath = path.join(release.destination, release.fileName);
 
   try {
-    //fs.mkdirSync(release.destination);
-
     const buffer = await fileFromUrl(url);
     fs.writeFileSync(fpath, buffer);
 
@@ -168,6 +176,8 @@ async function downloadBinary(release: Release) {
     if (process.env.downloader_log === 'true') {
       console.log(`Download completed`);
     }
+
+    untarFiles(fpath);
   } catch (error) {
     console.log(error);
     throw new Error(`Release download failed version: ${release.version}, fileName: ${release.fileName}`);

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -36,16 +36,17 @@ function getPlatform(platform: string) {
 function getArch(arch: string) {
   // platform | terraform-ls  | extension platform | vs code editor
   //    --    |           --  |         --         | --
-  // macOS    | darwin_amd64  | darwin_x64         | ✅
+  // macOS    | darwin_x86_64  | darwin_x64         | ✅
   // macOS    | darwin_arm64  | darwin_arm64       | ✅
-  // Linux    | linux_amd64   | linux_x64          | ✅
+  // Linux    | linux_x86_64   | linux_x64          | ✅
   // Linux    | linux_arm     | linux_armhf        | ✅
   // Linux    | linux_arm64   | linux_arm64        | ✅
-  // Windows  | windows_amd64 | win32_x64          | ✅
+  // Windows  | windows_x86_64 | win32_x64          | ✅
   // Windows  | windows_arm64 | win32_arm64        | ✅
   if (arch === 'x64') {
-    return 'amd64';
+    return 'x86_64';
   }
+
   if (arch === 'armhf') {
     return 'arm';
   }

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -86,8 +86,8 @@ async function downloadLanguageServer(platform: string, architecture: string, ex
   const buildDir = path.basename(cwd);
   const repoDir = cwd.replace(buildDir, '');
   const installPath = path.join(repoDir, 'bin');
-  const filename = os === 'windows' ? 'tofu-ls.exe' : 'tofu-ls';
-  const packageName = os === 'windows' ? `tofu-ls_${capitalize(os)}_${arch}.exe` : `tofu-ls_${capitalize(os)}_${arch}`;
+  const filename = 'tofu-ls';
+  const packageName = `tofu-ls_${capitalize(os)}_${arch}`;
   const filePath = path.join(installPath, filename);
   if (fs.existsSync(filePath)) {
     if (process.env.downloader_log === 'true') {
@@ -99,7 +99,7 @@ async function downloadLanguageServer(platform: string, architecture: string, ex
   fs.mkdirSync(installPath);
 
   await fetchVersion({
-    repository: 'gamunu/opentofu-ls',
+    repository: 'opentofu/tofu-ls',
     package: packageName,
     destination: installPath,
     fileName: filename,
@@ -151,7 +151,7 @@ async function downloadSyntax(info: ExtensionInfo) {
 
 export async function fetchVersion(release: Release): Promise<void> {
   validateRelease(release);
-  await downloadTarGz(release);
+  await downloadRelease(release);
 }
 
 function untarFiles(path: string) {
@@ -161,8 +161,10 @@ function untarFiles(path: string) {
   });
 }
 
-async function downloadTarGz(release: Release) {
+async function downloadRelease(release: Release) {
   const url = `https://github.com/${release.repository}/releases/download/v${release.version}/${release.package}.tar.gz`;
+
+  console.log('Downloading ', url);
 
   const fpath = path.join(release.destination, release.fileName);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@zodios/plugins": "^10.6.0",
         "axios": "^1.7.4",
         "semver": "^7.5.4",
+        "tar": "^7.4.3",
         "vscode-languageclient": "^9.0.1",
         "vscode-uri": "^3.0.7",
         "which": "^4.0.0",
@@ -1254,6 +1255,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -9708,10 +9721,21 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -9719,6 +9743,21 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
       "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
       "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -13428,6 +13467,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
@@ -13451,6 +13507,24 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.2.0"
+    "version": "0.0.2"
   },
   "syntax": {
     "version": "0.7.0"
@@ -718,6 +718,7 @@
     "@zodios/plugins": "^10.6.0",
     "axios": "^1.7.4",
     "semver": "^7.5.4",
+    "tar": "^7.4.3",
     "vscode-languageclient": "^9.0.1",
     "vscode-uri": "^3.0.7",
     "which": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.2"
+    "version": "0.0.1-alpha5"
   },
   "syntax": {
     "version": "0.7.0"


### PR DESCRIPTION
Resolves #1 

```
WARNING:

This PR is breaking half of the tests. I've fixed almost all of them
but I'll open other PRs to make it easier to review. 
```

In this work we're integrating with the `tofu-ls` binary, built from `https://github.com/opentofu/tofu-ls` instead of the previous `opentofu-ls` binary, that was using Terraform LSP.
Since the releases are on .tar.gz, we needed to install the `tar` package in order to untar the files.