### PR TITLE
Use `opentofu` language ID on LSP instead of `terraform`

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-
-
 import { defineConfig } from '@vscode/test-cli';
 import fs from 'fs';
 import path from 'path';

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,6 +96,14 @@ To run the `integration` tests in PowerShell, set the environment variable accor
 
 The tests can also be run within VSCode itself, using the launch task `Run Extension Tests`. This will open a new VS Code window, run the test suite, and exit with the test results.
 
+To run specific tests, use:
+
+
+```powershell
+> npm test -- -g "root document completion"
+```
+
+
 ### Acceptance Tests
 
 End to end acceptance tests with the extension running against the language server are a work in progress. An example can be seen in [`./src/test/integration/symbols.test.ts`](src/test/integration/symbols.test.ts).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTofu Extension for Visual Studio Code
 
-[OpenTofu Extension for Visual Studio Code (VS Code)](https://marketplace.visualstudio.com/items?itemName=gamunu.opentofu) with the [Terraform Language Server](https://github.com/hashicorp/terraform-ls) adds editing features for [OpenTofu](https://opentofu.org/) files such as syntax highlighting, IntelliSense, code navigation, code formatting, module explorer and much more!
+[OpenTofu Extension for Visual Studio Code (VS Code)](https://marketplace.visualstudio.com/items?itemName=opentofu.opentofu) with the [Terraform Language Server](https://github.com/hashicorp/terraform-ls) adds editing features for [OpenTofu](https://opentofu.org/) files such as syntax highlighting, IntelliSense, code navigation, code formatting, module explorer and much more!
 
 ## Quick Start
 
@@ -8,7 +8,7 @@ Get started writing OpenTofu configurations with VS Code in three steps:
 
 - **Step 1:** If you haven't done so already, install [OpenTofu](https://opentofu.org/docs/intro/install/)
 
-- **Step 2:** Install the [OpenTofu Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=gamunu.opentofu).
+- **Step 2:** Install the [OpenTofu Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=opentofu.opentofu).
 
 - **Step 3:** To activate the extension, open any folder or VS Code workspace containing OpenTofu files. Once activated, the OpenTofu language indicator will appear in the bottom right corner of the window.
 
@@ -187,7 +187,7 @@ To provide the extension with an up-to-date schema for the OpenTofu providers us
 
 The Visual Studio Code [Remote - WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) lets you use the Windows Subsystem for Linux (WSL) as your full-time development environment right from VS Code. You can author OpenTofu configuration files in a Linux-based environment, use Linux-specific toolchains and utilities from the comfort of Windows.
 
-The Remote WSL extension runs the [OpenTofu Extension](https://marketplace.visualstudio.com/items?itemName=gamunu.opentofu) and other extensions directly in WSL so you can edit files located in WSL or the mounted Windows filesystem (for example /mnt/c) without worrying about pathing issues, binary compatibility, or other cross-OS challenges.
+The Remote WSL extension runs the [OpenTofu Extension](https://marketplace.visualstudio.com/items?itemName=opentofu.opentofu) and other extensions directly in WSL so you can edit files located in WSL or the mounted Windows filesystem (for example /mnt/c) without worrying about pathing issues, binary compatibility, or other cross-OS challenges.
 
 For a detailed walkthrough for how to get started using WSL and VS Code, see https://code.visualstudio.com/docs/remote/wsl-tutorial.
 
@@ -233,12 +233,12 @@ To enable automatic formatting, it is recommended that the following be added to
 
 ```json
 "[terraform]": {
-  "editor.defaultFormatter": "gamunu.opentofu",
+  "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file"
 },
 "[terraform-vars]": {
-  "editor.defaultFormatter": "gamunu.opentofu",
+  "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file"
 }
@@ -253,14 +253,14 @@ If you want to use `editor.codeActionsOnSave` with `editor.formatOnSave` to auto
 ```json
 "editor.formatOnSave": true,
 "[terraform]": {
-  "editor.defaultFormatter": "gamunu.opentofu",
+  "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.formatAll.opentofu": true
   },
 },
 "[terraform-vars]": {
-  "editor.defaultFormatter": "gamunu.opentofu",
+  "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.formatAll.opentofu": true

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -34,7 +34,7 @@ function getPlatform(platform: string) {
 }
 
 function getArch(arch: string) {
-  // platform | terraform-ls  | extension platform | vs code editor
+  // platform | tofu-ls  | extension platform | vs code editor
   //    --    |           --  |         --         | --
   // macOS    | darwin_x86_64  | darwin_x64         | ✅
   // macOS    | darwin_arm64  | darwin_arm64       | ✅

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
   "contributes": {
     "languages": [
       {
-        "id": "terraform",
+        "id": "opentofu",
         "aliases": [
           "OpenTofu",
-          "opentofu",
           "tofu",
+          "terraform",
           "hcl"
         ],
         "extensions": [
@@ -70,7 +70,7 @@
         "configuration": "./language-configuration.json"
       },
       {
-        "id": "terraform-vars",
+        "id": "opentofu-vars",
         "extensions": [
           ".tfvars"
         ],
@@ -141,12 +141,12 @@
     ],
     "grammars": [
       {
-        "language": "terraform",
+        "language": "opentofu",
         "scopeName": "source.hcl.terraform",
         "path": "./syntaxes/terraform.tmGrammar.json"
       },
       {
-        "language": "terraform-vars",
+        "language": "opentofu-vars",
         "scopeName": "source.hcl.terraform",
         "path": "./syntaxes/terraform.tmGrammar.json"
       },
@@ -356,7 +356,7 @@
     },
     "snippets": [
       {
-        "language": "terraform",
+        "language": "opentofu",
         "path": "./snippets/opentofu.json"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.1-alpha5"
+    "version": "0.0.1-alpha7"
   },
   "syntax": {
     "version": "0.7.0"

--- a/src/api/terraform/terraform.ts
+++ b/src/api/terraform/terraform.ts
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
+
 import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient } from 'vscode-languageclient/node';
+
 import { Utils } from 'vscode-uri';
-import { getActiveTextEditor } from './../../utils/vscode';
 import { clientSupportsCommand } from './../../utils/clientHelpers';
+import { getActiveTextEditor } from './../../utils/vscode';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export interface ModuleCaller {
@@ -55,7 +57,7 @@ export interface TerraformInfoResponse {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export async function terraformVersion(moduleUri: string, client: LanguageClient): Promise<TerraformInfoResponse> {
-  const command = 'terraform-ls.module.terraform';
+  const command = 'tofu-ls.module.terraform';
 
   const response = await execWorkspaceLSCommand<TerraformInfoResponse>(command, moduleUri, client);
 
@@ -63,7 +65,7 @@ export async function terraformVersion(moduleUri: string, client: LanguageClient
 }
 
 export async function moduleCallers(moduleUri: string, client: LanguageClient): Promise<ModuleCallersResponse> {
-  const command = 'terraform-ls.module.callers';
+  const command = 'tofu-ls.module.callers';
 
   const response = await execWorkspaceLSCommand<ModuleCallersResponse>(command, moduleUri, client);
 
@@ -71,7 +73,7 @@ export async function moduleCallers(moduleUri: string, client: LanguageClient): 
 }
 
 export async function moduleCalls(moduleUri: string, client: LanguageClient): Promise<ModuleCallsResponse> {
-  const command = 'terraform-ls.module.calls';
+  const command = 'tofu-ls.module.calls';
 
   const response = await execWorkspaceLSCommand<ModuleCallsResponse>(command, moduleUri, client);
 
@@ -79,7 +81,7 @@ export async function moduleCalls(moduleUri: string, client: LanguageClient): Pr
 }
 
 export async function moduleProviders(moduleUri: string, client: LanguageClient): Promise<ModuleProvidersResponse> {
-  const command = 'terraform-ls.module.providers';
+  const command = 'tofu-ls.module.providers';
 
   const response = await execWorkspaceLSCommand<ModuleProvidersResponse>(command, moduleUri, client);
 
@@ -102,7 +104,7 @@ export async function initAskUserCommand(client: LanguageClient) {
     }
 
     const moduleUri = selected[0];
-    const command = `terraform-ls.terraform.init`;
+    const command = `tofu-ls.terraform.init`;
 
     return execWorkspaceLSCommand<void>(command, moduleUri.toString(), client);
   } catch (error) {
@@ -173,7 +175,7 @@ async function terraformCommand(command: string, client: LanguageClient, useShel
     return;
   }
 
-  const fullCommand = `terraform-ls.terraform.${command}`;
+  const fullCommand = `tofu-ls.terraform.${command}`;
 
   return execWorkspaceLSCommand<void>(fullCommand, selectedModule, client);
 }
@@ -182,14 +184,14 @@ async function execWorkspaceLSCommand<T>(command: string, moduleUri: string, cli
   // record whether we use terraform.init or terraform.initcurrent vscode commands
   // this is hacky, but better than propagating down another parameter just to handle
   // which init command we used
-  if (command === 'terraform-ls.terraform.initCurrent') {
-    // need to change to terraform-ls command after detection
-    command = 'terraform-ls.terraform.init';
+  if (command === 'tofu-ls.terraform.initCurrent') {
+    // need to change to tofu-ls command after detection
+    command = 'tofu-ls.terraform.init';
   }
 
   const commandSupported = clientSupportsCommand(client.initializeResult, command);
   if (!commandSupported) {
-    throw new Error(`${command} not supported by this terraform-ls version`);
+    throw new Error(`${command} not supported by this tofu-ls version`);
   }
 
   const params: ExecuteCommandParams = {

--- a/src/commands/terraformls.ts
+++ b/src/commands/terraformls.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
+
 import { config, getScope } from '../utils/vscode';
 
 export class TerraformLSCommands implements vscode.Disposable {
@@ -12,7 +13,7 @@ export class TerraformLSCommands implements vscode.Disposable {
   constructor() {
     this.commands = [
       vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
-        if (event.affectsConfiguration('opentofu') || event.affectsConfiguration('terraform-ls')) {
+        if (event.affectsConfiguration('opentofu') || event.affectsConfiguration('tofu-ls')) {
           const reloadMsg = 'Reload VSCode window to apply language server changes';
           const selected = await vscode.window.showInformationMessage(reloadMsg, 'Reload');
           if (selected === 'Reload') {
@@ -38,17 +39,17 @@ export class TerraformLSCommands implements vscode.Disposable {
 
         await config('opentofu').update('languageServer.enable', false, scope);
       }),
-      vscode.commands.registerCommand('terraform.openSettingsJson', async () => {
+      vscode.commands.registerCommand('opentofu.openSettingsJson', async () => {
         // this opens the default settings window (either UI or json)
         const s = await vscode.workspace.getConfiguration('workbench').get('settings.editor');
         if (s === 'json') {
           return await vscode.commands.executeCommand('workbench.action.openSettingsJson', {
-            revealSetting: { key: 'terraform.languageServer.enable', edit: true },
+            revealSetting: { key: 'opentofu.languageServer.enable', edit: true },
           });
         } else {
           return await vscode.commands.executeCommand('workbench.action.openSettings', {
             focusSearch: true,
-            query: '@ext:hashicorp.terraform',
+            query: '@ext:opentofu.opentofu',
           });
         }
       }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,8 +40,6 @@ const brand = `OpenTofu`;
 const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'opentofu' },
   { scheme: 'file', language: 'opentofu-vars' },
-  { scheme: 'file', language: 'terraform-stack' },
-  { scheme: 'file', language: 'terraform-deploy' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,8 +38,8 @@ import { getServerOptions } from './utils/clientHelpers';
 const id = 'opentofu';
 const brand = `OpenTofu`;
 const documentSelector: DocumentSelector = [
-  { scheme: 'file', language: 'terraform' },
-  { scheme: 'file', language: 'terraform-vars' },
+  { scheme: 'file', language: 'opentofu' },
+  { scheme: 'file', language: 'opentofu-vars' },
   { scheme: 'file', language: 'terraform-stack' },
   { scheme: 'file', language: 'terraform-deploy' },
 ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+import * as lsStatus from './status/language';
 import * as vscode from 'vscode';
+
 import {
   CloseAction,
   DocumentSelector,
@@ -16,22 +18,22 @@ import {
   RevealOutputChannelOn,
   State,
 } from 'vscode-languageclient/node';
-import { getServerOptions } from './utils/clientHelpers';
-import { GenerateBugReportCommand } from './commands/generateBugReport';
-import { ModuleCallsDataProvider } from './providers/terraform/moduleCalls';
-import { ModuleProvidersDataProvider } from './providers/terraform/moduleProviders';
-import { ServerPath } from './utils/serverPath';
 import { config, handleLanguageClientStartError } from './utils/vscode';
-import { ShowReferencesFeature } from './features/showReferences';
+
 import { CustomSemanticTokens } from './features/semanticTokens';
-import { ModuleProvidersFeature } from './features/moduleProviders';
-import { ModuleCallsFeature } from './features/moduleCalls';
-import { TerraformVersionFeature } from './features/terraformVersion';
+import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { LanguageStatusFeature } from './features/languageStatus';
-import { getInitializationOptions } from './settings';
-import { TerraformLSCommands } from './commands/terraformls';
+import { ModuleCallsDataProvider } from './providers/terraform/moduleCalls';
+import { ModuleCallsFeature } from './features/moduleCalls';
+import { ModuleProvidersDataProvider } from './providers/terraform/moduleProviders';
+import { ModuleProvidersFeature } from './features/moduleProviders';
+import { ServerPath } from './utils/serverPath';
+import { ShowReferencesFeature } from './features/showReferences';
 import { TerraformCommands } from './commands/terraform';
-import * as lsStatus from './status/language';
+import { TerraformLSCommands } from './commands/terraformls';
+import { TerraformVersionFeature } from './features/terraformVersion';
+import { getInitializationOptions } from './settings';
+import { getServerOptions } from './utils/clientHelpers';
 
 const id = 'opentofu';
 const brand = `OpenTofu`;
@@ -81,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     initializationFailedHandler: (error: ResponseError<InitializeError> | Error | any) => {
       initializationError = error;
 
-      let msg = 'Failure to start opentofu-ls. Please check your configuration settings and reload this window';
+      let msg = 'Failure to start tofu-ls. Please check your configuration settings and reload this window';
 
       const serverArgs = config('opentofu').get<string[]>('languageServer.args', []);
       if (serverArgs[0] !== 'serve') {
@@ -160,10 +162,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // write to log and stop attempting to restart server
         // initializationFailedHandler will handle showing an error to user
         outputChannel.appendLine(
-          'Failure to start opentofu-ls. Please check your configuration settings and reload this window',
+          'Failure to start tofu-ls. Please check your configuration settings and reload this window',
         );
         return {
-          message: 'Failure to start opentofu-ls. Please check your configuration settings and reload this window',
+          message: 'Failure to start tofu-ls. Please check your configuration settings and reload this window',
           action: CloseAction.DoNotRestart,
         };
       },

--- a/src/providers/terraform/moduleProviders.ts
+++ b/src/providers/terraform/moduleProviders.ts
@@ -5,9 +5,11 @@
 
 import * as terraform from '../../api/terraform/terraform';
 import * as vscode from 'vscode';
-import { Utils } from 'vscode-uri';
+
 import { getActiveTextEditor, isTerraformFile } from '../../utils/vscode';
+
 import { LanguageClient } from 'vscode-languageclient/node';
+import { Utils } from 'vscode-uri';
 
 class ModuleProviderItem extends vscode.TreeItem {
   constructor(
@@ -38,7 +40,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
     private client: LanguageClient,
   ) {
     ctx.subscriptions.push(
-      vscode.commands.registerCommand('terraform.providers.refreshList', () => this.refresh()),
+      vscode.commands.registerCommand('opentofu.providers.refreshList', () => this.refresh()),
       vscode.window.onDidChangeActiveTextEditor(async () => {
         // most of the time this is called when the user switches tabs or closes the file
         // we already check for state inside the getprovider function, so we can just call refresh here

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,11 +8,11 @@ export interface InitializationOptions {
   indexing?: IndexingOptions;
   experimentalFeatures?: ExperimentalFeatures;
   ignoreSingleFileWarning?: boolean;
-  terraform?: TerraformOptions;
+  opentofu?: TofuOptions;
   validation?: ValidationOptions;
 }
 
-export interface TerraformOptions {
+export interface TofuOptions {
   path: string;
   timeout: string;
   logFilePath: string;
@@ -42,7 +42,7 @@ export async function getInitializationOptions() {
     enableEnhancedValidation: true,
   });
 
-  const terraform = config('opentofu').get<TerraformOptions>('languageServer.opentofu', {
+  const tofuOptions = config('opentofu').get<TofuOptions>('languageServer.opentofu', {
     path: '',
     timeout: '',
     logFilePath: '',
@@ -67,7 +67,7 @@ export async function getInitializationOptions() {
     validation,
     experimentalFeatures,
     ignoreSingleFileWarning,
-    terraform,
+    opentofu: tofuOptions,
     ...(rootModulePaths.length > 0 && { rootModulePaths }),
     indexing,
   };

--- a/src/status/installedVersion.ts
+++ b/src/status/installedVersion.ts
@@ -6,8 +6,8 @@
 import * as vscode from 'vscode';
 
 const installedVersion = vscode.languages.createLanguageStatusItem('opentofu.installedVersion', [
-  { language: 'terraform' },
-  { language: 'terraform-vars' },
+  { language: 'opentofu' },
+  { language: 'opentofu-vars' },
 ]);
 installedVersion.name = 'OpenTofuInstalledVersion';
 installedVersion.detail = 'OpenTofu Installed';

--- a/src/status/language.ts
+++ b/src/status/language.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode';
 
-const lsStatus = vscode.languages.createLanguageStatusItem('terraform-ls.status', [
-  { language: 'terraform' },
-  { language: 'terraform-vars' },
+const lsStatus = vscode.languages.createLanguageStatusItem('tofu-ls.status', [
+  { language: 'opentofu' },
+  { language: 'opentofu-vars' },
 ]);
 lsStatus.name = 'OpenTofu LS';
 lsStatus.detail = 'OpenTofu LS';

--- a/src/status/requiredVersion.ts
+++ b/src/status/requiredVersion.ts
@@ -6,8 +6,8 @@
 import * as vscode from 'vscode';
 
 const requiredVersion = vscode.languages.createLanguageStatusItem('opentofu.requiredVersion', [
-  { language: 'terraform' },
-  { language: 'terraform-vars' },
+  { language: 'opentofu' },
+  { language: 'opentofu-vars' },
 ]);
 requiredVersion.name = 'OpenTofuRequiredVersion';
 requiredVersion.detail = 'OpenTofu Required';

--- a/src/test/e2e/specs/extension.e2e.ts
+++ b/src/test/e2e/specs/extension.e2e.ts
@@ -15,7 +15,7 @@ describe('VS Code Extension Testing', () => {
     const extensions = await browser.executeWorkbench((vscodeApi) => {
       return vscodeApi.extensions.all;
     });
-    expect(extensions.some((extension) => extension.id === 'hashicorp.terraform')).toBe(true);
+    expect(extensions.some((extension) => extension.id === 'opentofu.opentofu')).toBe(true);
   });
 
   it('should show all activity bar items', async () => {

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -3,8 +3,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 
 export async function open(docUri: vscode.Uri): Promise<void> {
   try {
@@ -147,7 +147,7 @@ export async function testSymbols(docUri: vscode.Uri, symbolNames: string[]) {
 }
 
 export async function activateExtension() {
-  const ext = vscode.extensions.getExtension('hashicorp.terraform');
+  const ext = vscode.extensions.getExtension('opentofu.opentofu');
   if (!ext?.isActive) {
     await ext?.activate();
     await sleep(1000);

--- a/src/test/integration/basics/codeAction.test.ts
+++ b/src/test/integration/basics/codeAction.test.ts
@@ -3,10 +3,12 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { expect } from 'chai';
+import * as vscode from 'vscode';
+
 import { activateExtension, getDocUri, open, sleep } from '../../helper';
+
+import { expect } from 'chai';
 
 suite('code actions', () => {
   suite('format all', function suite() {
@@ -23,7 +25,7 @@ suite('code actions', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('formats the document', async () => {

--- a/src/test/integration/basics/completion.test.ts
+++ b/src/test/integration/basics/completion.test.ts
@@ -4,8 +4,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
-import { assert } from 'chai';
+
 import { activateExtension, getDocUri, open, testCompletion } from '../../helper';
+
+import { assert } from 'chai';
 
 const snippets = [
   new vscode.CompletionItem({ label: 'fore', description: 'For Each' }, vscode.CompletionItemKind.Snippet),
@@ -31,7 +33,7 @@ suite('completion', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('simple completion', async () => {
@@ -70,7 +72,7 @@ suite('completion', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     // Completion for inputs of a local module
@@ -97,9 +99,11 @@ suite('completion', () => {
         new vscode.CompletionItem('"./compute"', vscode.CompletionItemKind.Text),
       ];
 
-      if (vscode.version <= '1.82.3') {
-        expected.push(...snippets);
-      }
+      // TODO: This test is breaking on vscode 1.100.4.
+      // Comparing semver versions is not so simple as comparing the strings with <=
+      // if (vscode.version <= '1.82.3') {
+      // expected.push(...snippets);
+      // }
 
       // module "compute" {
       //   source = "./compute"
@@ -126,7 +130,7 @@ suite('completion', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('inputs of a registry module', async () => {
@@ -157,7 +161,7 @@ suite('completion', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform-vars', 'document language should be `terraform-vars`');
+      assert.equal(doc.languageId, 'opentofu-vars', 'document language should be `opentofu-vars`');
     });
 
     test('simple variable completion', async () => {

--- a/src/test/integration/basics/definition.test.ts
+++ b/src/test/integration/basics/definition.test.ts
@@ -3,8 +3,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
+
 import { activateExtension, getDocUri, open, testDefinitions } from '../../helper';
 
 suite('definitions', () => {
@@ -22,7 +23,7 @@ suite('definitions', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('returns definition for module source', async () => {
@@ -77,7 +78,7 @@ suite('definitions', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform-vars', 'document language should be `terraform-vars`');
+      assert.equal(doc.languageId, 'opentofu-vars', 'document language should be `opentofu-vars`');
     });
 
     test('returns definition for module source', async () => {

--- a/src/test/integration/basics/hover.test.ts
+++ b/src/test/integration/basics/hover.test.ts
@@ -3,8 +3,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
+
 import { activateExtension, getDocUri, open, testHover } from '../../helper';
 
 suite('hover', () => {
@@ -22,7 +23,7 @@ suite('hover', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('returns docs for terraform block', async () => {

--- a/src/test/integration/basics/references.test.ts
+++ b/src/test/integration/basics/references.test.ts
@@ -3,8 +3,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
+
 import { activateExtension, getDocUri, open, testReferences } from '../../helper';
 
 suite('references', () => {
@@ -22,7 +23,7 @@ suite('references', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('returns definition for module source', async () => {

--- a/src/test/integration/basics/symbols.test.ts
+++ b/src/test/integration/basics/symbols.test.ts
@@ -3,8 +3,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
+
 import { activateExtension, getDocUri, open, testSymbols } from '../../helper';
 
 suite('symbols', () => {
@@ -22,7 +23,7 @@ suite('symbols', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('returns symbols', async () => {

--- a/src/test/integration/basics/workspace/main.tf
+++ b/src/test/integration/basics/workspace/main.tf
@@ -21,4 +21,3 @@ module "compute" {
   instance_name = "terraform-machine"
 
 }
-

--- a/src/test/integration/basics/workspace/registry_module.tf
+++ b/src/test/integration/basics/workspace/registry_module.tf
@@ -1,6 +1,6 @@
 module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "5.8.0"
+  source  = "registry.opentofu.org/terraform-aws-modules/vpc/aws"
+  version = "5.18.0"
 
   external_
 }

--- a/src/test/integration/init/init.test.ts
+++ b/src/test/integration/init/init.test.ts
@@ -4,8 +4,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
+
+import { activateExtension, getDocUri, open, sleep, testCompletion } from '../../helper';
+
 import { assert } from 'chai';
-import { activateExtension, getDocUri, open, testCompletion, sleep } from '../../helper';
 
 suite('init', () => {
   suite('with bundled provider schema', function suite() {
@@ -22,7 +24,7 @@ suite('init', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('completes resource available in bundled schema', async () => {
@@ -63,7 +65,7 @@ suite('init', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     /* test('completes resource not available in downloaded schema', async () => {
@@ -121,7 +123,7 @@ suite('init', () => {
 
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'terraform', 'document language should be `terraform`');
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
     });
 
     test('completes module from downloaded schema', async () => {

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -5,9 +5,11 @@
 
 import * as net from 'net';
 import * as vscode from 'vscode';
+
 import { Executable, InitializeResult, ServerOptions } from 'vscode-languageclient/node';
-import { config } from './vscode';
+
 import { ServerPath } from './serverPath';
+import { config } from './vscode';
 
 export async function getServerOptions(
   lsPath: ServerPath,

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -6,6 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as which from 'which';
+
 import { config } from './vscode';
 
 const INSTALL_FOLDER_NAME = 'bin';
@@ -39,9 +40,9 @@ export class ServerPath {
     }
 
     if (process.platform === 'win32') {
-      return 'opentofu-ls.exe';
+      return 'tofu-ls.exe';
     }
-    return 'opentofu-ls';
+    return 'tofu-ls';
   }
 
   public async resolvedPathToBinary(): Promise<string> {

--- a/test/specs/extension.ts
+++ b/test/specs/extension.ts
@@ -15,7 +15,7 @@ describe('VS Code Extension Testing', () => {
     const extensions = await browser.executeWorkbench((vscodeApi) => {
       return vscodeApi.extensions.all;
     });
-    expect(extensions.some((extension) => extension.id === 'hashicorp.terraform')).toBe(true);
+    expect(extensions.some((extension) => extension.id === 'opentofu.opentofu')).toBe(true);
   });
 
   it('should show all activity bar items', async () => {


### PR DESCRIPTION
Now that `tofu-ls` is [being used](https://github.com/opentofu/vscode-opentofu/pull/7) as the binary for the Language Server protocol server, we need to adjust the name of the language being used on the Client. `vscode-opentofu` was using `terraform` on the client, so the server is not returning the proper response. 

This PR is fixing 10 tests, the missing auto-completion test is being fixed in another PR in this repo and in multiple PRs on the `tofu-ls` repo.


Before:

<img width="564" alt="Screenshot 2025-05-26 at 10 39 45" src="https://github.com/user-attachments/assets/6cfe1a3f-099f-4d3c-85db-81ba4660ce34" />

After:

<img width="593" alt="Screenshot 2025-05-26 at 10 38 41" src="https://github.com/user-attachments/assets/6011d4e4-7570-48cf-8c51-ec9c9a9a4269" />

