### PR TITLE
using tofu as the prefix for commands and bump `tofu-ls` to `v0.0.1-alpha9`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.1-alpha7"
+    "version": "0.0.1-alpha9"
   },
   "syntax": {
     "version": "0.7.0"

--- a/src/api/terraform/terraform.ts
+++ b/src/api/terraform/terraform.ts
@@ -57,7 +57,7 @@ export interface TerraformInfoResponse {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export async function terraformVersion(moduleUri: string, client: LanguageClient): Promise<TerraformInfoResponse> {
-  const command = 'tofu-ls.module.terraform';
+  const command = 'tofu-ls.module.tofu';
 
   const response = await execWorkspaceLSCommand<TerraformInfoResponse>(command, moduleUri, client);
 
@@ -104,7 +104,7 @@ export async function initAskUserCommand(client: LanguageClient) {
     }
 
     const moduleUri = selected[0];
-    const command = `tofu-ls.terraform.init`;
+    const command = `tofu-ls.tofu.init`;
 
     return execWorkspaceLSCommand<void>(command, moduleUri.toString(), client);
   } catch (error) {
@@ -175,7 +175,7 @@ async function terraformCommand(command: string, client: LanguageClient, useShel
     return;
   }
 
-  const fullCommand = `tofu-ls.terraform.${command}`;
+  const fullCommand = `tofu-ls.tofu.${command}`;
 
   return execWorkspaceLSCommand<void>(fullCommand, selectedModule, client);
 }
@@ -184,9 +184,9 @@ async function execWorkspaceLSCommand<T>(command: string, moduleUri: string, cli
   // record whether we use terraform.init or terraform.initcurrent vscode commands
   // this is hacky, but better than propagating down another parameter just to handle
   // which init command we used
-  if (command === 'tofu-ls.terraform.initCurrent') {
+  if (command === 'tofu-ls.tofu.initCurrent') {
     // need to change to tofu-ls command after detection
-    command = 'tofu-ls.terraform.init';
+    command = 'tofu-ls.tofu.init';
   }
 
   const commandSupported = clientSupportsCommand(client.initializeResult, command);

--- a/src/commands/generateBugReport.ts
+++ b/src/commands/generateBugReport.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import child_process = require('child_process');
+
 import * as os from 'os';
 import * as vscode from 'vscode';
 
@@ -32,7 +33,7 @@ export class GenerateBugReportCommand implements vscode.Disposable {
         const extensions = this.getExtensions();
         const body = await this.generateBody(extensions, problemText);
         const encodedBody = encodeURIComponent(body);
-        const fullUrl = `https://github.com/gamunu/vscode-opentofu/issues/new?body=${encodedBody}`;
+        const fullUrl = `https://github.com/opentofu/vscode-opentofu/issues/new?body=${encodedBody}`;
         vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(fullUrl));
       }),
     );

--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -3,9 +3,10 @@
 // Copyright (c) 2024 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
 import * as terraform from '../api/terraform/terraform';
+import * as vscode from 'vscode';
+
+import { LanguageClient } from 'vscode-languageclient/node';
 
 export class TerraformCommands implements vscode.Disposable {
   private commands: vscode.Disposable[];

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
+
 import {
   BaseLanguageClient,
   ClientCapabilities,
@@ -11,8 +12,9 @@ import {
   ServerCapabilities,
   StaticFeature,
 } from 'vscode-languageclient';
-import { ModuleCallsDataProvider } from '../providers/terraform/moduleCalls';
+
 import { ExperimentalClientCapabilities } from './types';
+import { ModuleCallsDataProvider } from '../providers/terraform/moduleCalls';
 
 const CLIENT_MODULE_CALLS_CMD_ID = 'client.refreshModuleCalls';
 

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as vscode from 'vscode';
+
 import {
   BaseLanguageClient,
   ClientCapabilities,
@@ -11,8 +12,9 @@ import {
   ServerCapabilities,
   StaticFeature,
 } from 'vscode-languageclient';
-import { ModuleProvidersDataProvider } from '../providers/terraform/moduleProviders';
+
 import { ExperimentalClientCapabilities } from './types';
+import { ModuleProvidersDataProvider } from '../providers/terraform/moduleProviders';
 
 export const CLIENT_MODULE_PROVIDERS_CMD_ID = 'client.refreshModuleProviders';
 

--- a/src/providers/terraform/moduleCalls.ts
+++ b/src/providers/terraform/moduleCalls.ts
@@ -6,9 +6,11 @@
 import * as path from 'path';
 import * as terraform from '../../api/terraform/terraform';
 import * as vscode from 'vscode';
+
+import { getActiveTextEditor, isTerraformFile } from '../../utils/vscode';
+
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { getActiveTextEditor, isTerraformFile } from '../../utils/vscode';
 
 class ModuleCallItem extends vscode.TreeItem {
   constructor(


### PR DESCRIPTION
Resolves #4

> Warning: CI/CD is broken on this PR due to unrelated changes: https://github.com/opentofu/vscode-opentofu/issues/19

This PR is covering two parts:

1 - `tofu-ls` is using `tofu` as the prefix for the commands. The changes for this part are like:

<img width="977" alt="Screenshot 2025-05-28 at 15 31 05" src="https://github.com/user-attachments/assets/d2089fd0-bc61-4571-a419-9c292a4bf5bc" />


2 - `tofu-ls` was bumped to `v0.0.1-alpha9`. It means a few bugs were fixed on the backend of the Language Server Protocol, and are making their way on this repo.


Output of the tests before:
<img width="1119" alt="Screenshot 2025-05-28 at 07 20 32" src="https://github.com/user-attachments/assets/0d3cbdf8-0579-43db-8d24-ab33be263524" />

After:

<img width="394" alt="Screenshot 2025-05-28 at 15 43 35" src="https://github.com/user-attachments/assets/abadff02-8f50-48f4-ac01-49bd3de4aedc" />