### PR TITLE
Updates deployment platforms based on the new changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
           - stable
           - prerelease
       langserver:
-        description: 'The terraform-ls version to use. If not specified will use version in package.json'
+        description: 'The tofu-ls version to use. If not specified will use version in package.json'
         required: false
         type: string
 
@@ -30,19 +30,19 @@ jobs:
             ls_target: web_noop
             npm_config_arch: x64
           - vsce_target: win32-x64
-            ls_target: windows_amd64
+            ls_target: windows_x86_64
             npm_config_arch: x64
           - vsce_target: win32-arm64
             ls_target: windows_arm64
             npm_config_arch: arm
           - vsce_target: linux-x64
-            ls_target: linux_amd64
+            ls_target: linux_x86_64
             npm_config_arch: x64
           - vsce_target: linux-arm64
             ls_target: linux_arm64
             npm_config_arch: arm64
           - vsce_target: darwin-x64
-            ls_target: darwin_amd64
+            ls_target: darwin_x86_64
             npm_config_arch: x64
           - vsce_target: darwin-arm64
             ls_target: darwin_arm64

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "OpenTofu",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
   "version": "0.2.1",
-  "publisher": "gamunu",
+  "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,
   "private": true,


### PR DESCRIPTION
Solves #5 
We will need to create accounts for [OpenVSX (if we decide to continue publishing there)](https://open-vsx.org/) and a publisher account for [VSCode Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher) 
After we have accounts for those, we must set OVSX_PAT and VSCE_PAT as the [repository secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions?tool=webui)