### PR TITLE
bump tofu-ls to v0.0.2 and add new tests

### DIFF
--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -43,7 +43,7 @@ function getArch(arch: string) {
   // Linux    | linux_arm64   | linux_arm64        | ✅
   // Windows  | windows_x86_64 | win32_x64          | ✅
   // Windows  | windows_arm64 | win32_arm64        | ✅
-  if (arch === 'x64') {
+  if (['x64', 'x86'].includes(arch)) {
     return 'x86_64';
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "icon": "assets/icons/opentofu_logo_universal.png",
   "name": "vscode-opentofu",
-  "displayName": "OpenTofu",
+  "displayName": "VSCode - OpenTofu",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
   "version": "0.2.1",
   "publisher": "opentofu",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.1-alpha9"
+    "version": "0.0.2"
   },
   "syntax": {
     "version": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "icon": "assets/icons/opentofu_logo_universal.png",
-  "name": "opentofu",
+  "name": "vscode-opentofu",
   "displayName": "OpenTofu",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
   "version": "0.2.1",

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -82,7 +82,19 @@ export async function testHover(docUri: vscode.Uri, position: vscode.Position, e
   assert.equal(actualhover.length, expectedCompletionList.length);
   expectedCompletionList.forEach((expectedItem, i) => {
     const actualItem = actualhover[i];
-    assert.deepStrictEqual(actualItem.contents, expectedItem.contents);
+
+    // deepStrictEqual is not working as expected, that's why we
+    // are using a for loop and then checking the content
+    expectedItem.contents.forEach((expectedContent, j) => {
+      const actualItemContent = actualItem.contents[j];
+      assert.equal(
+        (expectedContent as vscode.MarkdownString).value,
+        (actualItemContent as vscode.MarkdownString).value,
+      );
+    });
+
+    assert.deepStrictEqual(actualItem.range!.start, expectedItem.range!.start);
+    assert.deepStrictEqual(actualItem.range!.end, expectedItem.range!.end);
   });
 }
 

--- a/src/test/integration/basics/completion.test.ts
+++ b/src/test/integration/basics/completion.test.ts
@@ -166,6 +166,8 @@ suite('completion', () => {
 
     test('simple variable completion', async () => {
       const expected = [
+        new vscode.CompletionItem('aws_active_regions', vscode.CompletionItemKind.Property),
+        new vscode.CompletionItem('aws_disabled_regions', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('credentials_file', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('project', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('region', vscode.CompletionItemKind.Property),

--- a/src/test/integration/basics/hover.test.ts
+++ b/src/test/integration/basics/hover.test.ts
@@ -32,7 +32,7 @@ suite('hover', () => {
           new vscode.MarkdownString(
             '**terraform** _Block_\n\nTerraform block used to configure some high-level behaviors of Terraform',
           ),
-          new vscode.Range(new vscode.Position(14, 12), new vscode.Position(14, 20)),
+          new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 9)),
         ),
       ]);
     });

--- a/src/test/integration/basics/references.test.ts
+++ b/src/test/integration/basics/references.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { activateExtension, getDocUri, open, testReferences } from '../../helper';
+import { activateExtension, getDocUri, open, testHover, testReferences } from '../../helper';
 
 suite('references', () => {
   suite('module references', function suite() {
@@ -39,4 +39,36 @@ suite('references', () => {
       ]);
     });
   });
+
+  suite('provider references', function suite() {
+    const docUri = getDocUri('provider_foreach.tf');
+
+    this.beforeAll(async () => {
+      await open(docUri);
+      await activateExtension();
+    });
+
+    teardown(async () => {
+      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+
+    test('language is registered', async () => {
+      const doc = await vscode.workspace.openTextDocument(docUri);
+      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
+    });
+
+    // Creating this test for testing the alias provider reference and if for_each argument is shown without errors
+    test('hovering for-each attribute at provider', async () => {
+      await testHover(docUri, new vscode.Position(12, 2), [
+        new vscode.Hover(
+          new vscode.MarkdownString(
+            '**for_each** _optional, map of any single type or set of string or object_\n\nA meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.',
+          ),
+          new vscode.Range(new vscode.Position(12, 2), new vscode.Position(12, 35)),
+        ),
+      ]);
+    });
+  });
+
+  suite.skip('provider alias reference', async () => {});
 });

--- a/src/test/integration/basics/workspace/provider_foreach.tf
+++ b/src/test/integration/basics/workspace/provider_foreach.tf
@@ -1,0 +1,28 @@
+variable "aws_active_regions" {
+  type    = set(string)
+  default = ["us-east-1", "sa-east-1"]
+}
+variable "aws_disabled_regions" {
+  description = "A list of regions that should be disabled and all resources removed."
+  type        = set(string)
+  default     = []
+}
+// Superset of the provider configuration
+provider "aws" {
+  alias    = "by_region"
+  for_each = var.aws_active_regions
+  region   = each.key
+}
+// Resource using a subset of the provider's configuration
+resource "aws_cloudwatch_log_group" "lambda_cloudfront" {
+  name     = "/aws/lambda/${each.key}.lambda"
+  provider = aws.by_region[each.key]
+  for_each = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
+}
+
+module "ai" {
+  source = "./ai"
+
+  providers = aws.by_region[each.key]
+  for_each  = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
+}


### PR DESCRIPTION
- Bumping `tofu-ls` to `v0.0.2` to add `for_each` attribute to provider `block`;
- Fixes `testHover`. Its content and range were not being asserted properly; This screenshot shows how it's being tested correctly now, before even different contents were passing:

<img width="757" alt="Screenshot 2025-05-30 at 18 43 20" src="https://github.com/user-attachments/assets/7def7c23-ec61-4c19-963d-8d38cb714263" />


- Add a test to make sure `provider` `for_each` is being showing the hovered text correctly.

<img width="802" alt="Screenshot 2025-05-30 at 18 50 16" src="https://github.com/user-attachments/assets/ca0182d3-2954-4d32-b7a6-8c3f1eb9d10e" />
