### PR TITLE
add support for .tofu and .tofutest.hcl file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
           "hcl"
         ],
         "extensions": [
-          ".tf"
+          ".tf",
+          ".tofu"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -107,10 +108,11 @@
       {
         "id": "terraform-test",
         "aliases": [
-          "Terraform Test"
+          "OpenTofu Test"
         ],
         "extensions": [
-          ".tftest.hcl"
+          ".tftest.hcl",
+          ".tofutest.hcl"
         ],
         "configuration": "./language-configuration.json",
         "icon": {


### PR DESCRIPTION
The extension was not previously applied to `.tofu` and `.tofutest.hcl` files, only to `tf` related files. Adding them on this PR.