### PR TITLE
add opentofu icon as the fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
         "extensions": [
           ".tf"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "assets/icons/opentofu.svg",
+          "light": "assets/icons/opentofu.svg"
+        }
       },
       {
         "id": "opentofu-vars",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
         ],
         "configuration": "./language-configuration.json",
         "icon": {
-          "dark": "assets/icons/terraform_stacks.svg",
-          "light": "assets/icons/terraform_stacks.svg"
+          "dark": "assets/icons/opentofu.svg",
+          "light": "assets/icons/opentofu.svg"
         }
       },
       {
@@ -100,8 +100,8 @@
         ],
         "configuration": "./language-configuration.json",
         "icon": {
-          "dark": "assets/icons/terraform_stacks.svg",
-          "light": "assets/icons/terraform_stacks.svg"
+          "dark": "assets/icons/opentofu.svg",
+          "light": "assets/icons/opentofu.svg"
         }
       },
       {
@@ -114,8 +114,8 @@
         ],
         "configuration": "./language-configuration.json",
         "icon": {
-          "dark": "assets/icons/terraform_stacks.svg",
-          "light": "assets/icons/terraform_stacks.svg"
+          "dark": "assets/icons/opentofu.svg",
+          "light": "assets/icons/opentofu.svg"
         }
       },
       {
@@ -128,8 +128,8 @@
         ],
         "configuration": "./language-configuration.json",
         "icon": {
-          "dark": "assets/icons/terraform_stacks.svg",
-          "light": "assets/icons/terraform_stacks.svg"
+          "dark": "assets/icons/opentofu.svg",
+          "light": "assets/icons/opentofu.svg"
         }
       },
       {


### PR DESCRIPTION
According to https://github.com/microsoft/vscode/issues/140047, we can't specify icons on the file listing, but if `File Icon Themes` do not specify an icon, this will be used as a fallback.


<img width="188" alt="Screenshot 2025-05-30 at 20 54 18" src="https://github.com/user-attachments/assets/c15d3499-4e37-4106-a92e-3eb1c6c088db" />
