### PR TITLE
Bump tofu-ls to v0.0.7 and add tests for provider alias references

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.6"
+    "version": "0.0.7"
   },
   "syntax": {
     "version": "0.7.0"

--- a/src/test/integration/basics/hover.test.ts
+++ b/src/test/integration/basics/hover.test.ts
@@ -61,4 +61,28 @@ suite('hover', () => {
       ]);
     });
   });
+
+  suite('provider for_each', function suite() {
+    const docUri = getDocUri('provider_foreach.tf');
+
+    this.beforeAll(async () => {
+      await open(docUri);
+      await activateExtension();
+    });
+
+    teardown(async () => {
+      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+
+    test('hovering for-each attribute at provider', async () => {
+      await testHover(docUri, new vscode.Position(12, 2), [
+        new vscode.Hover(
+          new vscode.MarkdownString(
+            '**for_each** _optional, map of any single type or set of string or object_\n\nA meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.',
+          ),
+          new vscode.Range(new vscode.Position(12, 2), new vscode.Position(12, 35)),
+        ),
+      ]);
+    });
+  });
 });

--- a/src/test/integration/basics/references.test.ts
+++ b/src/test/integration/basics/references.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { activateExtension, getDocUri, open, testHover, testReferences } from '../../helper';
+import { activateExtension, getDocUri, open, testReferences } from '../../helper';
 
 suite('references', () => {
   suite('module references', function suite() {
@@ -55,18 +55,6 @@ suite('references', () => {
     test('language is registered', async () => {
       const doc = await vscode.workspace.openTextDocument(docUri);
       assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
-    });
-
-    // Creating this test for testing the alias provider reference and if for_each argument is shown without errors
-    test('hovering for-each attribute at provider', async () => {
-      await testHover(docUri, new vscode.Position(12, 2), [
-        new vscode.Hover(
-          new vscode.MarkdownString(
-            '**for_each** _optional, map of any single type or set of string or object_\n\nA meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.',
-          ),
-          new vscode.Range(new vscode.Position(12, 2), new vscode.Position(12, 35)),
-        ),
-      ]);
     });
   });
 

--- a/src/test/integration/basics/references.test.ts
+++ b/src/test/integration/basics/references.test.ts
@@ -52,11 +52,18 @@ suite('references', () => {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
-    test('language is registered', async () => {
-      const doc = await vscode.workspace.openTextDocument(docUri);
-      assert.equal(doc.languageId, 'opentofu', 'document language should be `opentofu`');
+    test('provider alias references', async () => {
+      // alias = by_region
+      await testReferences(docUri, new vscode.Position(12, 10), [
+        new vscode.Location(docUri, new vscode.Range(new vscode.Position(13, 13), new vscode.Position(13, 21))),
+        new vscode.Location(docUri, new vscode.Range(new vscode.Position(18, 13), new vscode.Position(18, 26))),
+        new vscode.Location(docUri, new vscode.Range(new vscode.Position(24, 13), new vscode.Position(24, 26))),
+      ]);
+
+      // alias = by_name
+      await testReferences(docUri, new vscode.Position(29, 17), [
+        new vscode.Location(docUri, new vscode.Range(new vscode.Position(36, 13), new vscode.Position(36, 24))),
+      ]);
     });
   });
-
-  suite.skip('provider alias reference', async () => {});
 });

--- a/src/test/integration/basics/workspace/provider_foreach.tf
+++ b/src/test/integration/basics/workspace/provider_foreach.tf
@@ -20,9 +20,20 @@ resource "aws_cloudwatch_log_group" "lambda_cloudfront" {
   for_each = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
 }
 
-module "ai" {
-  source = "./ai"
+resource "aws_cloudwatch_log_group" "lambda_cloudfront_2" {
+  name     = "/aws/lambda/${each.key}.lambda"
+  provider = aws.by_region[each.key]
+  for_each = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
+}
 
-  providers = aws.by_region[each.key]
-  for_each  = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
+provider "aws" {
+  alias    = "by_name"
+  for_each = var.aws_active_regions
+  region   = each.key
+}
+
+resource "aws_cloudwatch_log_group" "lambda_cloudfront_3" {
+  name     = "/aws/lambda/${each.key}.lambda"
+  provider = aws.by_name[each.key]
+  for_each = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
 }


### PR DESCRIPTION
Blocked by https://github.com/opentofu/opentofu-schema/pull/32

This PR is adding integration tests for having the definition and references for provider alias.

I'm moving one hover test to the appropriate place too.