### PR TITLE
tofu-ls version bump and v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2 (2025-06-20)
+- `encryption` block key providers now support all available options
+
 ## 0.3.1 (2025-06-19)
 - displayName change to "OpenTofu (official)"
 - Fixes LS binary options, "opentofu" -> "tofu"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-opentofu",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-opentofu",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@zodios/core": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-opentofu",
   "displayName": "OpenTofu (official)",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   "syntax": {
     "version": "0.7.0"


### PR DESCRIPTION
 `encryption` block key providers now support all available options