### PR TITLE
fix: `tofu` binary configuration

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,7 @@ export interface InitializationOptions {
   indexing?: IndexingOptions;
   experimentalFeatures?: ExperimentalFeatures;
   ignoreSingleFileWarning?: boolean;
-  opentofu?: TofuOptions;
+  tofu?: TofuOptions;
   validation?: ValidationOptions;
 }
 
@@ -67,7 +67,7 @@ export async function getInitializationOptions() {
     validation,
     experimentalFeatures,
     ignoreSingleFileWarning,
-    opentofu: tofuOptions,
+    tofu: tofuOptions,
     ...(rootModulePaths.length > 0 && { rootModulePaths }),
     indexing,
   };


### PR DESCRIPTION
Fixes #66 

When we renamed the options to use the `tofu` binary: https://github.com/opentofu/tofu-ls/pull/80, we broke the way configuration options are passed to tofu-ls. Updating the field to `tofu` make it work.