### PR TITLE
fix: when releasing from tags, publish is not being called

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
     name: Publish Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: success() && inputs.deploy_type == 'stable'
+    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to Marketplace
@@ -127,7 +127,7 @@ jobs:
     name: Publish OpenVSX
     runs-on: ubuntu-latest
     needs: build
-    if: success() && inputs.deploy_type == 'stable'
+    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to OpenVSX


### PR DESCRIPTION
Previously, the publishing of this extension was being done in a manual step, on the `release.yml` workflow.

While working on https://github.com/opentofu/vscode-opentofu/pull/72, I've added the support to trigger this workflow when pushing the tags, in order to decrease the manual steps. It didn't work, since the Publish steps were skipped.

I've noticed there are two checks for `inputs.deploy_type` on "Publish Marketplace" and "Publish OpenVSX" but these input are defined only by calling the workflow manually. 

My fix here would test if the workflow is called manually or if it's coming from tags in order to trigger it.

https://github.com/opentofu/vscode-opentofu/blob/main/.github/workflows/release.yml#L106