### PR TITLE
bump: `tofu-ls` to `v0.0.8` and `vscode-opentofu` to `v0.3.4`

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,7 @@ Release process:
 
    - Bump the language server version in `package.json` if the release should include a [LS update](https://github.com/opentofu/tofu-ls/releases)
    - Update the [CHANGELOG.md](../CHANGELOG.md) with the recent changes
-   - Bump the version in `package.json` (and `package-lock.json`) by using `npm version X.Y.Z`. This automatically creates a git commit.
+   - Bump the version in `package.json` (and `package-lock.json`) by using `npm version X.Y.Z --no-git-tag-version`. This automatically creates a git commit.
 1. Review & merge the branch and wait for the [Test Workflow](https://github.com/opentofu/vscode-opentofu/actions/workflows/test.yml) on `main` to complete.
 1. Go to the [Draft a new release page](https://github.com/opentofu/vscode-opentofu/releases/new);
 1. Click on "Choose a tag", type "vX.Y.Z", then click on the "Create a new tag: vX.Y.Z" label;

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,7 @@ Release process:
 
    - Bump the language server version in `package.json` if the release should include a [LS update](https://github.com/opentofu/tofu-ls/releases)
    - Update the [CHANGELOG.md](../CHANGELOG.md) with the recent changes
-   - Bump the version in `package.json` (and `package-lock.json`) by using `npm version X.Y.Z --no-git-tag-version`. This automatically creates a git commit.
+   - Bump the version in `package.json` (and `package-lock.json`) manually.
 1. Review & merge the branch and wait for the [Test Workflow](https://github.com/opentofu/vscode-opentofu/actions/workflows/test.yml) on `main` to complete.
 1. Go to the [Draft a new release page](https://github.com/opentofu/vscode-opentofu/releases/new);
 1. Click on "Choose a tag", type "vX.Y.Z", then click on the "Create a new tag: vX.Y.Z" label;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.4 (2025-07-07)
+- Adding references to complex object variables
+
 ## 0.3.3 (2025-06-26)
 - Matching `removed` block schema to OpenTofu implementation
 - Adding references to provider for each on LSP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-opentofu",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-opentofu",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@zodios/core": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-opentofu",
   "displayName": "OpenTofu (official)",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "syntax": {
     "version": "0.7.0"


### PR DESCRIPTION
- Bumping `tofu-ls` to `v0.0.8` 
- Bumping `vscode-opentofu` to `v0.3.4`
- Adapting the Release document with the changes I needed to do:
  - `npm version` does not include an option for `--signoff`, so I switched to do this step manually.