### PR TITLE
fix: building the `package` when pushing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         run: npm run package -- --githubBranch $GITHUB_REF_NAME --pre-release --target=${{ matrix.vsce_target }}
 
       - name: Package Stable VSIX
-        if: inputs.deploy_type == 'stable'
+        if: (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
         run: npm run package -- --target=${{ matrix.vsce_target }}
 
       - name: Upload vsix as artifact


### PR DESCRIPTION
Related to https://github.com/opentofu/vscode-opentofu/pull/73

It seems we need one extra step in order to `prepare the package` to be used on the `publish` step.