### PR TITLE
Simplify VSCode settings examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ If you want to use `editor.codeActionsOnSave` with `editor.formatOnSave` to auto
 ```json
 "editor.formatOnSave": true,
 "[opentofu][opentofu-vars]": {
-  "editor.defaultFormatter": "opentofu.opentofu",
+  "editor.defaultFormatter": "opentofu.vscode-opentofu",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.formatAll.opentofu": true

--- a/README.md
+++ b/README.md
@@ -232,12 +232,7 @@ Display reference counts above top level blocks and attributes
 To enable automatic formatting, it is recommended that the following be added to the extension settings for the OpenTofu extension:
 
 ```json
-"[opentofu]": {
-  "editor.defaultFormatter": "opentofu.opentofu",
-  "editor.formatOnSave": true,
-  "editor.formatOnSaveMode": "file"
-},
-"[opentofu-vars]": {
+"[opentofu][opentofu-vars]": {
   "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file"
@@ -252,14 +247,7 @@ If you want to use `editor.codeActionsOnSave` with `editor.formatOnSave` to auto
 
 ```json
 "editor.formatOnSave": true,
-"[opentofu]": {
-  "editor.defaultFormatter": "opentofu.opentofu",
-  "editor.formatOnSave": false,
-  "editor.codeActionsOnSave": {
-    "source.formatAll.opentofu": true
-  },
-},
-"[opentofu-vars]": {
+"[opentofu][opentofu-vars]": {
   "editor.defaultFormatter": "opentofu.opentofu",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ To enable automatic formatting, it is recommended that the following be added to
 
 ```json
 "[opentofu][opentofu-vars]": {
-  "editor.defaultFormatter": "opentofu.opentofu",
+  "editor.defaultFormatter": "opentofu.vscode-opentofu",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file"
 }


### PR DESCRIPTION
## Description

The VSCode `settings.json` examples in the README show duplicate settings for `[opentofu]` and `[opentofu-vars]` language keys.

This is unnecessary because [multiple language keys can be included together](https://code.visualstudio.com/docs/configure/settings#_multiple-languagespecific-editor-settings).

This:

```json
{
  "[opentofu]": {
    "editor.defaultFormatter": "opentofu.opentofu",
    "editor.formatOnSave": true,
    "editor.formatOnSaveMode": "file"
  },
  "[opentofu-vars]": {
    "editor.defaultFormatter": "opentofu.opentofu",
    "editor.formatOnSave": true,
    "editor.formatOnSaveMode": "file"
  }
}
```

Can be written like this:

```json
{
  "[opentofu][opentofu-vars]": {
    "editor.defaultFormatter": "opentofu.opentofu",
    "editor.formatOnSave": true,
    "editor.formatOnSaveMode": "file"
  }
}
```

## Changes

This PR will remove the unnecessary code duplication in the VSCode `settings.json` examples in the README.

## Related

- [VSCode Docs: User and Workspace Settings](https://code.visualstudio.com/docs/configure/settings)
