### PR TITLE
do not trigger `check-changelog.yml` if `.github` is touched

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -4,8 +4,8 @@
 
 on:
   pull_request:
-    paths:
-      - !.github/**
+    paths-ignore:
+      - '.github/**'
     branches:
       - main
       - pre-release


### PR DESCRIPTION
This was supposed to be added in a previous commit, but the syntax was invalid. We still need to accept one of the third-party actions being used there, but it can be done in a subsequent commit. 

To fix: 
https://github.com/opentofu/vscode-opentofu/actions/runs/17594594612