### PR TITLE
Assign opentofu icons to all the languages we support

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
           ".tf",
           ".tofu"
         ],
+        "icon": {
+          "light": "./assets/icons/opentofu.svg",
+          "dark": "./assets/icons/opentofu.svg"
+        },
         "configuration": "./language-configuration.json"
       },
       {
@@ -74,6 +78,10 @@
         "extensions": [
           ".tfvars"
         ],
+        "icon": {
+          "light": "./assets/icons/opentofu.svg",
+          "dark": "./assets/icons/opentofu.svg"
+        },
         "configuration": "./language-configuration.json"
       },
       {
@@ -83,6 +91,10 @@
           "Terraform Test",
           "terraform-test"
         ],
+        "icon": {
+          "light": "./assets/icons/opentofu.svg",
+          "dark": "./assets/icons/opentofu.svg"
+        },
         "extensions": [
           ".tftest.hcl",
           ".tofutest.hcl"
@@ -96,6 +108,10 @@
           "Terraform Mock",
           "terraform-mock"
         ],
+        "icon": {
+          "light": "./assets/icons/opentofu.svg",
+          "dark": "./assets/icons/opentofu.svg"
+        },
         "extensions": [
           ".tfmock.hcl"
         ],


### PR DESCRIPTION
Resolves #95 

---

Assign OpenTofu icons to all the languages we support.
Currently, this will work for `*.tofu` files and all of them will gain icons. If the icon theme supports it, this change will also override `*.tf`, `*.tfvars`,`*.tftest ,` `*.tofutest.hcl` and `*.tfmock.hcl`
Read more about it https://code.visualstudio.com/api/extension-guides/file-icon-theme#language-default-icons

TL;DR; If the icon theme defines `"showLanguageModeIcons":true`, OpenTofu icons will appear on all of the files mentioned above.