### PR TITLE
v0.4.2

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,7 @@ Release process:
 
    - Bump the language server version in `package.json` if the release should include a [LS update](https://github.com/opentofu/tofu-ls/releases)
    - Update the [CHANGELOG.md](../CHANGELOG.md) with the recent changes
-   - Bump the version in `package.json` (and `package-lock.json`) manually.
+   - Bump the version in by running `npm version vX.Y.Z --no-git-tag-version` - creates unstaged version update in package.json and package-lock.json files.
 1. Review & merge the branch and wait for the [Test Workflow](https://github.com/opentofu/vscode-opentofu/actions/workflows/test.yml) on `main` to complete.
 1. Go to the [Draft a new release page](https://github.com/opentofu/vscode-opentofu/releases/new);
 1. Click on "Choose a tag", type "vX.Y.Z", then click on the "Create a new tag: vX.Y.Z" label;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-opentofu",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-opentofu",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@zodios/core": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-opentofu",
   "displayName": "OpenTofu (official)",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,


### PR DESCRIPTION
Version update and Release.md update (for now), removing manual update mention in favour of the correct `npm version` command


---


We have missed the version update part of the last release, which caused the publishing part to fail.
I will propose an alternative process for releases after.