### PR TITLE
New release flow

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -9,4 +9,4 @@ Release process:
     - If the release should include `tofu-ls` version update, set the `ls-version` input, ex: 0.1.0, latest, etc.
 1. Once the workflow is finished, review the PR it created. Make adjustments if necessary and merge it.
 
-That is the whole flow. Once the PR is merged, `Release` workflow will be triggered automatically.
+That is the whole flow. Once the PR is merged, the `Release` workflow will be triggered automatically.

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,14 +4,9 @@ Releases are made on a reasonably regular basis by the maintainers, using the [v
 
 Release process:
 
-1. Create a release branch/PR with the following changes:
+1. Once everything we need to include in the release in on the *main* branch, trigger "Prepare Release" workflow.
+    - Depending on which type of release we are doing, select either: major, minor or patch.
+    - If the release should include `tofu-ls` version update, set the `ls-version` input, ex: 0.1.0, latest, etc.
+1. Once the workflow is finished, review the PR it created. Make adjustments if necessary and merge it.
 
-   - Bump the language server version in `package.json` if the release should include a [LS update](https://github.com/opentofu/tofu-ls/releases)
-   - Update the [CHANGELOG.md](../CHANGELOG.md) with the recent changes
-   - Bump the version in by running `npm version vX.Y.Z --no-git-tag-version` - creates unstaged version update in package.json and package-lock.json files.
-1. Review & merge the branch and wait for the [Test Workflow](https://github.com/opentofu/vscode-opentofu/actions/workflows/test.yml) on `main` to complete.
-1. Go to the [Draft a new release page](https://github.com/opentofu/vscode-opentofu/releases/new);
-1. Click on "Choose a tag", type "vX.Y.Z", then click on the "Create a new tag: vX.Y.Z" label;
-1. Click on "Generate release notes" in order to add an auto-generated description and copy the CHANGELOG.md changes on the top of the description.
-1. Click on "Publish Release" to finish the process. The `release.yml` workflow
-will be triggered in response to this event.
+That is the whole flow. Once the PR is merged, `Release` workflow will be triggered automatically.

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -11,6 +11,7 @@ changelog:
     - title: New Features
       labels:
         - feature
+        - enhancement
     - title: Bugs Fixed
       labels:
         - bug

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,3 +1,7 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2024 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
 changelog:
   exclude:
     labels:

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - release
+      - dependencies
+  categories:
+    - title: New Features
+      labels:
+        - feature
+    - title: Bugs Fixed
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -104,7 +104,7 @@ jobs:
           echo "branch_name=release/$next_version" >> $GITHUB_OUTPUT
 
       - name: Update `tofu-ls` version
-        if: ${{ steps.ls_version.outputs.updates_ls_version}}
+        if: ${{ steps.ls_version.outputs.updates_ls_version }}
         run: |
           jq '.langServer.version = "${{ steps.ls_version.outputs.ls_version }}"' package.json > package_temp.json
           mv package_temp.json package.json

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -192,7 +192,7 @@ jobs:
 
           ### Changes:
           - Updated version from ${{ steps.version.outputs.current_version }} to ${{ steps.version.outputs.next_version }}
-          $(if [ -n "${{ steps.version.outputs.updates_ls_version }}" ]; then echo "- Updated `tofu-ls` version to ${{ inputs.ls_version }}"; fi)
+          $(if [ -n "${{ steps.ls_version.outputs.updates_ls_version }}" ]; then echo "- Updated `tofu-ls` version to ${{ inputs.ls_version }}"; fi)
           - Added changelog for the new version and a new entry in CHANGELOG.md with auto-generated release notes
 
           ### Generated Release Notes:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,7 +14,7 @@ on:
           - minor
           - major
       ls_version:
-        description: 'New `tofu-ls` version (optional)'
+        description: 'New `tofu-ls` version (optional) - "latest" or a specific version (without v prefix)'
         required: false
         type: string
 
@@ -39,9 +39,62 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get latest release tag
+        id: latest_release
+        run: |
+          latest_tag=$(gh release view --json tagName | jq -r '.tagName')
+          echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get LS versions and check if `langServer.version` needs update
+        id: ls_version
+        run: |
+          # Version of tofu-ls
+          current_ls_version=$(jq -r '.langServer.version' package.json)
+
+          # Latest tofu-ls version
+          latest_ls_version=$(gh release view -R opentofu/tofu-ls --json tagName | jq -r '.tagName')
+
+          # Check if we need to update the language server version and set it in output
+          # We are updating ls version if specified non-empty version.
+          ls_version="${{ inputs.ls_version }}"
+          # Flag to indicate this workflow will need to update the ls version
+          updates_ls_version=false
+          if [ "$ls_version" != "" ]; then
+            # If specified version is 'latest' and the current version is the latest, we don't update the version.
+            if [ "$ls_version" == "latest" ] && [ "$current_ls_version" == "$latest_ls_version" ]; then
+              ls_version=$latest_ls_version
+            else
+              # $ls_version in this case is already set from input
+              updates_ls_version=true
+              echo "ls_version_changed=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            ls_version=$current_ls_version
+          fi
+
+          # Even if the ls version wasn't set during the workflow run it still can be different from the one in the last release of the extension
+          # We can check if that is the case
+          if [[ $updates_ls_version == false ]]; then
+            # We can get the langServer set in the last release using `git show` and latest tag we obtained in the last set
+            previous_version=$(git show ${{ steps.latest_release.outputs.latest_tag }}:package.json | jq -r '.langServer.version')
+            # We add a new flag to indicate the case, when tofu-ls version changed but not necessarily by the workflow and we can prepend it in release notes
+            if [[ "$previous_version" != "$current_ls_version" ]]; then
+              echo "ls_version_changed=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          # This output indicates what the ls version will be after it is updated in the next step
+          # Hence, it is set to the current version if no update occurs
+          echo "ls_version=$ls_version" >> $GITHUB_OUTPUT
+          echo "updates_ls_version=$updates_ls_version" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get current version and update it to the next one
         id: version
         run: |
+          # Get current version of the extension
           current_version=$(jq -r '.version' package.json)
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
@@ -50,10 +103,10 @@ jobs:
           echo "next_version=$next_version" >> $GITHUB_OUTPUT
           echo "branch_name=release/$next_version" >> $GITHUB_OUTPUT
 
-      - name: Update langServer version if provided
-        if: inputs.ls_version != ''
+      - name: Update `tofu-ls` version
+        if: ${{ steps.ls_version.outputs.updates_ls_version}}
         run: |
-          jq '.langServer.version = "${{ inputs.ls_version }}"' package.json > package_temp.json
+          jq '.langServer.version = "${{ steps.ls_version.outputs.ls_version }}"' package.json > package_temp.json
           mv package_temp.json package.json
 
       - name: Configure bot and Create a release branch
@@ -61,12 +114,6 @@ jobs:
           git config user.name "OpenTofu Maintainers [bot]"
           git config user.email "maintainers@opentofu.org"
           git checkout -b ${{ steps.version.outputs.branch_name }}
-
-      - name: Get latest release tag
-        id: latest_release
-        run: |
-          latest_tag=$(gh release view --json tagName | jq -r '.tagName')
-          echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
 
       - name: Generate release notes
         id: release_notes
@@ -84,10 +131,19 @@ jobs:
             }')
             # Extract the body from the response and append to summary
             release_notes=$(echo "$response" | jq -r '.body')
-            echo "release_notes=$release_notes" >> $GITHUB_OUTPUT
+            # Remove a line starting with "## What's Changed" and a comment from notes
+            release_notes=$(echo "$release_notes" | sed "/^## What's Changed/d" | sed "/^<!--.*-->/d")
+            # If we updated the ls version, we need to insert that note at the start.
+            # This checks version change by the workflow and difference from the last version
+            if [[ "${{ steps.ls_version.outputs.ls_version_changed }}" = "true" ]]; then
+              release_notes="*Includes a new LS version - [tofu-ls ${{steps.ls_version.outputs.ls_version}}](https://github.com/opentofu/tofu-ls/releases/tag/v${{ steps.ls_version.outputs.ls_version }})*
+              ${release_notes}"
+            fi
+            # To avoid errors due to multiline notes strings, we encode and decode it in base 64
+            encoded_release_notes=$(echo "$release_notes" | base64 --wrap=0)
+            echo "release_notes=$encoded_release_notes" >> $GITHUB_OUTPUT
             echo "$release_notes" >> $GITHUB_STEP_SUMMARY
 
-      # TODO we can also fetch the release notes from tofu-ls releases if the ls verion changed and embed them here
       - name: Create version changelog file and Update CHANGELOG.md
         id: changelog_entry
         run: |
@@ -95,12 +151,12 @@ jobs:
           current_date=$(date +"%Y-%m-%d")
 
           # Create changelog file in .changes
-          release_file=".changes/${{ steps.version.outputs.next_version }}"
-
+          release_file=".changes/${{ steps.version.outputs.next_version }}.md"
+          decoded_release_notes=$(echo "${{steps.release_notes.outputs.release_notes}}" | base64 --decode)
           {
             echo "## ${{ steps.version.outputs.next_version }} ($current_date)"
             echo ""
-            echo "${{steps.release_notes.output.release_notes}}"
+            echo "$decoded_release_notes"
           } > $release_file
 
           # Create new changelog entry
@@ -136,7 +192,7 @@ jobs:
 
           ### Changes:
           - Updated version from ${{ steps.version.outputs.current_version }} to ${{ steps.version.outputs.next_version }}
-          $(if [ -n "${{ inputs.ls_version }}" ]; then echo "- Updated langServer version to ${{ inputs.ls_version }}"; fi)
+          $(if [ -n "${{ steps.version.outputs.updates_ls_version }}" ]; then echo "- Updated `tofu-ls` version to ${{ inputs.ls_version }}"; fi)
           - Added changelog for the new version and a new entry in CHANGELOG.md with auto-generated release notes
 
           ### Generated Release Notes:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,160 @@
+---
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      ls_version:
+        description: 'New `tofu-ls` version (optional)'
+        required: false
+        type: string
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get current version and update it to the next one
+        id: version
+        run: |
+          current_version=$(jq -r '.version' package.json)
+          echo "current_version=$current_version" >> $GITHUB_OUTPUT
+
+          # Calculate next version using `npm version` command. The `next_version` includes the 'v' prefix
+          next_version=$(npm version "${{ inputs.version_bump }}" --no-git-tag-version)
+          echo "next_version=$next_version" >> $GITHUB_OUTPUT
+          echo "branch_name=release/$next_version" >> $GITHUB_OUTPUT
+
+      - name: Update langServer version if provided
+        if: inputs.ls_version != ''
+        run: |
+          jq '.langServer.version = "${{ inputs.ls_version }}"' package.json > package_temp.json
+          mv package_temp.json package.json
+
+      - name: Configure bot and Create a release branch
+        run: |
+          git config user.name "OpenTofu Maintainers [bot]"
+          git config user.email "maintainers@opentofu.org"
+          git checkout -b ${{ steps.version.outputs.branch_name }}
+
+      - name: Get latest release tag
+        id: latest_release
+        run: |
+          latest_tag=$(gh release view --json tagName | jq -r '.tagName')
+          echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          # Use GitHub API to generate release notes
+          response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -X POST \
+            "https://api.github.com/repos/${{ github.repository }}/releases/generate-notes" \
+            -d '{
+              "tag_name": "${{ steps.version.outputs.next_version }}",
+              "target_commitish": "${{ github.ref_name }}",
+              "configuration_file_path": ".github/release-notes.yml",
+              "previous_tag_name": "${{ steps.latest_release.outputs.latest_tag }}"
+            }')
+            # Extract the body from the response and append to summary
+            release_notes=$(echo "$response" | jq -r '.body')
+            echo "release_notes=$release_notes" >> $GITHUB_OUTPUT
+            echo "$release_notes" >> $GITHUB_STEP_SUMMARY
+
+      # TODO we can also fetch the release notes from tofu-ls releases if the ls verion changed and embed them here
+      - name: Create version changelog file and Update CHANGELOG.md
+        id: changelog_entry
+        run: |
+          # Get the current date
+          current_date=$(date +"%Y-%m-%d")
+
+          # Create changelog file in .changes
+          release_file=".changes/${{ steps.version.outputs.next_version }}"
+
+          {
+            echo "## ${{ steps.version.outputs.next_version }} ($current_date)"
+            echo ""
+            echo "${{steps.release_notes.output.release_notes}}"
+          } > $release_file
+
+          # Create new changelog entry
+          # Here we retain the header (# Changelog) and appending the whole content of the $release_file
+          {
+            echo "# Changelog"
+            echo ""
+            cat "$release_file"
+            echo ""
+            # Add the rest of the existing changelog (skip the header)
+            tail -n +2 CHANGELOG.md
+          } > CHANGELOG_new.md
+
+          mv CHANGELOG_new.md CHANGELOG.md
+          echo "release_file=$release_file" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        run: |
+          git add package.json package-lock.json CHANGELOG.md "${{ steps.changelog_entry.outputs.release_file }}"
+          git commit -m "chore: prepare release ${{ steps.version.outputs.next_version }}"
+          git push origin ${{ steps.version.outputs.branch_name }}
+
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --label "release" \
+            --title "Release ${{ steps.version.outputs.next_version }}" \
+            --body "$(cat <<EOF
+          ## Release ${{ steps.version.outputs.next_version }}
+
+          This PR prepares the automated release for version ${{ steps.version.outputs.next_version }}.
+          This PR is safe to modify.
+
+          ### Changes:
+          - Updated version from ${{ steps.version.outputs.current_version }} to ${{ steps.version.outputs.next_version }}
+          $(if [ -n "${{ inputs.ls_version }}" ]; then echo "- Updated langServer version to ${{ inputs.ls_version }}"; fi)
+          - Added changelog for the new version and a new entry in CHANGELOG.md with auto-generated release notes
+
+          ### Generated Release Notes:
+          $(cat "${{ steps.changelog_entry.outputs.release_file }}")
+          EOF
+          )" \
+            --head ${{ steps.version.outputs.branch_name }} \
+            --base ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Output summary
+        run: |
+          echo "## Release" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Current Version:** ${{ steps.version.outputs.current_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Next Version:** ${{ steps.version.outputs.next_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Branch:** ${{ steps.version.outputs.branch_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A pull request has been created with all the necessary changes." >> $GITHUB_STEP_SUMMARY
+          echo "Review and merge the PR to trigger the release." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -76,7 +76,7 @@ jobs:
           # Even if the ls version wasn't set during the workflow run it still can be different from the one in the last release of the extension
           # We can check if that is the case
           if [[ $updates_ls_version == false ]]; then
-            # We can get the langServer set in the last release using `git show` and latest tag we obtained in the last set
+            # We can get the langServer set in the last release using `git show` and latest tag we obtained in the last step
             previous_version=$(git show ${{ steps.latest_release.outputs.latest_tag }}:package.json | jq -r '.langServer.version')
             # We add a new flag to indicate the case, when tofu-ls version changed but not necessarily by the workflow and we can prepend it in release notes
             if [[ "$previous_version" != "$current_ls_version" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,64 @@ on:
         required: false
         type: string
   push:
-    tags: ["v*"]
+    tags: ['v*']
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
+  validate-release-pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    outputs:
+      has_release_label: ${{ steps.check_label.outputs.has_release_label }}
+    steps:
+      - name: Check if PR has release label
+        id: check_label
+        run: |
+          if [[ ${{ contains(github.event.pull_request.labels.*.name, 'release') }} ]]; then
+            echo "This workflow was triggered by the release PR merge"
+            echo "has_release_label=true" >> $GITHUB_OUTPUT
+          else
+            echo "PR does not have 'release' label. This workflow should only run for release PRs."
+            echo "has_release_label=false" >> $GITHUB_OUTPUT
+          fi
+
+  create-github-release:
+    runs-on: ubuntu-latest
+    needs: validate-release-pr
+    if: github.event.pull_request.merged == true && needs.validate-release-pr.outputs.has_release_label == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          version=$(jq -r '.version' package.json)
+          echo "version=v$version" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        run: |
+          changes_file=".changes/${{ steps.version.outputs.version }}.md"
+          if [[ -f "$changes_file" ]]; then
+            # We need to remove mention of version and date, since those are duplicate
+            notes=$(tail -n +3 "$changes_file")
+            gh release create ${{ steps.version.outputs.version }} \
+              --title "${{ steps.version.outputs.version }}" \
+              --notes "$notes"
+          else
+            echo "No changes file found. Creating a draft release."
+            gh release create ${{ steps.version.outputs.version }} \
+              --draft \
+              --title "${{ steps.version.outputs.version }}" \
+              --generate-notes
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   check-version-file:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
@@ -44,6 +99,9 @@ jobs:
           echo "Version check passed: ${{ steps.tag.outputs.version }}"
   build:
     name: Package
+    needs: [check-version-file, create-github-release, validate-release-pr]
+    # Triggering this workflow, either if it was triggered by the tag push and went through validation, or release PR was merged
+    if: always() && (needs.check-version-file.result == 'success' || (needs.create-github-release.result == 'success' && needs.validate-release-pr.outputs.has_release_label == 'true'))
     strategy:
       matrix:
         include:
@@ -72,6 +130,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -90,7 +150,9 @@ jobs:
         run: npm run package -- --githubBranch $GITHUB_REF_NAME --pre-release --target=${{ matrix.vsce_target }}
 
       - name: Package Stable VSIX
-        if: (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
+        # If the workflow trigger was manual, by tag push or by PR merge
+        # Currently release PR merge indicates stable release
+        if: (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
         run: npm run package -- --target=${{ matrix.vsce_target }}
 
       - name: Upload vsix as artifact
@@ -115,7 +177,7 @@ jobs:
     name: Publish Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
+    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to Marketplace
@@ -127,7 +189,7 @@ jobs:
     name: Publish OpenVSX
     runs-on: ubuntu-latest
     needs: build
-    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v'))
+    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to OpenVSX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Get version from package.json
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check if PR has release label
         id: check_label
         run: |
-          if [[ ${{ contains(github.event.pull_request.labels.*.name, 'release') }} ]]; then
+          if [[ ${{ contains(github.event.pull_request.labels.*.name, 'release') }} = "true" ]]; then
             echo "This workflow was triggered by the release PR merge"
             echo "has_release_label=true" >> $GITHUB_OUTPUT
           else

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -14,6 +14,7 @@ async function fileFromUrl(url: string): Promise<Buffer> {
   return Buffer.from(response.data, 'binary');
 }
 
+// New feature trigger
 export interface Release {
   repository: string;
   package: string;

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -14,7 +14,6 @@ async function fileFromUrl(url: string): Promise<Buffer> {
   return Buffer.from(response.data, 'binary');
 }
 
-// New feature trigger
 export interface Release {
   repository: string;
   package: string;
@@ -24,7 +23,6 @@ export interface Release {
   extract: boolean;
 }
 
-// a bug
 function getPlatform(platform: string) {
   if (platform === 'win32') {
     return 'windows';

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -24,6 +24,7 @@ export interface Release {
   extract: boolean;
 }
 
+// a bug
 function getPlatform(platform: string) {
   if (platform === 'win32') {
     return 'windows';


### PR DESCRIPTION
I have implemented a new workflow for releasing the extension.
This change allows us to do a release in 2 steps:
- Trigger `prepare_release` manually with the target release type of either: major, minor, or patch.
- Once the previous workflow prepares a PR, merge it, which will trigger the release.yml 
workflow for creating a release and publishing it to marketplaces.

We can also optionally include the `ls-version` input when triggering the workflow, and this automatically updates the version for the release. This can be used to update the LS version with the same flow, without additional PRs, since that is often the only change in releases.

What this does
---
### Part one - Release PR
1) Checks if `tofu-ls` version has been updated from the latest release (including updates in the current workflow run)
2) Uses GitHub [release API ](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release) to automatically generate release notes, based on the configuration defined in `.github/release-notes.yml`; Creates .changes/vX.y.z.md file with the changelog, and updates CHANGELOG.md.
3) In case the `tofu-ls` version has changed, adds that information to the release notes
4) Increments the extension version in "*Get current version and update it to the next one*" step
5) Creates a new branch called 'release/vX.y.z' and commits everything there as
```
    git config user.name "OpenTofu Maintainers [bot]"
    git config user.email "maintainers@opentofu.org"
```
6) Pushes everything and creates a PR for the release with label: *release*. This PR can be modified to include additional changelog entries or update existing ones.

### Part two - Publishing
1) Once the PR is reviewed and merged, it triggers the `release.yml` workflow.
2) We check if the trigger was the PR, by checking that the *release* label was included.
3) If `release.yml` was triggered by the PR, we create a GitHub release for it, with notes taken from the file under the `.changes/` directory. 
4) After all that, we use old logic for packaging and releasing to the marketplace.
---
Let me know if I have "bashed" too hard 😆 and this is hard to read. I have documented most of it with comments. However, if it is still difficult to comprehend, we could extract specific parts of the workflow in JavaScript.