### PR TITLE
deprecated name change - module.opentofu

### DIFF
--- a/src/api/opentofu/opentofu.ts
+++ b/src/api/opentofu/opentofu.ts
@@ -55,7 +55,7 @@ export interface TofuInfoResponse {
 }
 
 export async function tofuVersion(moduleUri: string, client: LanguageClient): Promise<TofuInfoResponse> {
-  const command = 'tofu-ls.module.tofu';
+  const command = 'tofu-ls.module.opentofu';
 
   return await execWorkspaceLSCommand<TofuInfoResponse>(command, moduleUri, client);
 }


### PR DESCRIPTION
We forgot to change this string, corresponding to LS, and it was showing a warning.