### PR TITLE
Add release support for alpine architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,12 @@ jobs:
           - vsce_target: darwin-arm64
             ls_target: darwin_arm64
             npm_config_arch: arm64
+          - vsce_target: alpine-x64
+            ls_target: alpine-x64
+            npm_config_arch: x64
+          - vsce_target: alpine-arm64
+            ls_target: alpine-arm64
+            npm_config_arch: arm64
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out repository


### PR DESCRIPTION
Resolves #106

Docs at https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions

"The currently available platforms are: win32-x64, win32-arm64, linux-x64, linux-arm64, linux-armhf, alpine-x64, alpine-arm64, darwin-x64, darwin-arm64 and web."