### PR TITLE
Publishing flow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
     name: Publish Prerelease to Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: success() && inputs.deploy_type == 'prerelease'
+    if: (! failure()) && (! cancelled()) && inputs.deploy_type == 'prerelease'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Prerelease to Marketplace
@@ -185,7 +185,7 @@ jobs:
     name: Publish Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
+    if: (! failure()) && (! cancelled()) && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to Marketplace
@@ -197,7 +197,7 @@ jobs:
     name: Publish OpenVSX
     runs-on: ubuntu-latest
     needs: build
-    if: success() && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
+    if: (! failure()) && (! cancelled()) && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to OpenVSX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ on:
         options:
           - stable
           - prerelease
-      langserver:
-        description: 'The tofu-ls version to use. If not specified will use version in package.json'
-        required: false
-        type: string
   push:
     tags: ['v*']
   pull_request:


### PR DESCRIPTION
Resolves #110 

This PR removes `success()` checks, which caused publishing workflows to be skipped entirely, and adds explicit `(! failure()) && (! cancelled())` checks for publishing workflows.
This also comments out the automatic trigger on pull requests until we solve the permission issues.

---

We have an issue with the publishing workflow.
This workflow previously failed but returned success because some previous steps were skipped, causing later publishing steps to be skipped silently and unexpectedly. Which I have missed during 0.5.0 deployment (Sorry everyone!)

https://github.com/opentofu/vscode-opentofu/actions/runs/18972630401 - Skipped steps can be seen here.

I haven't encountered this before: `success()` returns false even though the steps we are depending on have run successfully (using `always()`). 
Apparently, this is an issue with the GitHub workflows. See the [discussion here ](https://github.com/orgs/community/discussions/45058) 
