### PR TITLE
Another attempt at fixing the publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
   build:
     name: Package
     needs: [check-version-file, create-github-release, validate-release-pr]
-    # Triggering this workflow, either if it was triggered by the tag push and went through validation, or release PR was merged
-    if: always() && (needs.check-version-file.result == 'success' || (needs.create-github-release.result == 'success' && needs.validate-release-pr.outputs.has_release_label == 'true'))
+    # Triggering this workflow, either if it was triggered by the tag push and went through validation, or release PR was merged, hence we check if we created automated github release
+    if: always() && (needs.check-version-file.result == 'success' || needs.create-github-release.result == 'success')
     strategy:
       matrix:
         include:
@@ -169,7 +169,7 @@ jobs:
     name: Publish Prerelease to Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: (! failure()) && (! cancelled()) && inputs.deploy_type == 'prerelease'
+    if: always() && inputs.deploy_type == 'prerelease' && needs.build.result == 'success'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Prerelease to Marketplace
@@ -181,7 +181,8 @@ jobs:
     name: Publish Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: (! failure()) && (! cancelled()) && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
+    # Run if the build has succeeded and we are not doing prerelease
+    if: always() && inputs.deploy_type != 'prerelease' && needs.build.result == 'success'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to Marketplace
@@ -193,7 +194,8 @@ jobs:
     name: Publish OpenVSX
     runs-on: ubuntu-latest
     needs: build
-    if: (! failure()) && (! cancelled()) && (inputs.deploy_type == 'stable' || startsWith(github.ref, 'refs/tags/v') || github.event.pull_request.merged == true)
+    # Run if the build has succeeded and we are not doing prerelease
+    if: always() && inputs.deploy_type != 'prerelease' && needs.build.result == 'success'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Publish Stable to OpenVSX


### PR DESCRIPTION
In the previous PR, we changed `success()`, which caused additional issues: the last two workflows were not skipped when they should have been, and instead failed because the build step was skipped.
This is another attempt to solve the issue by depending directly on the `build` dependency status.