### PR TITLE
deps: pin `copywrite` version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: "Fetch source code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # We need to do comparisons against the main branch.
       - name: Setup Copywrite

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0 # We need to do comparisons against the main branch.
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           version: v0.24.2
       - name: "Copyright headers"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,9 @@ jobs:
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
+          # Newer versions of `copywrite` are broken in the OpenTofu project, because
+          # they handle the legacy project headers differently. We shouldn't upgrade
+          # past 0.24.2.
           version: v0.24.2
       - name: "Copyright headers"
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0 # We need to do comparisons against the main branch.
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        with:
+          version: v0.24.2
       - name: "Copyright headers"
         run: |
           copywrite headers --plan


### PR DESCRIPTION
While working at https://github.com/opentofu/vscode-opentofu/pull/130 I noticed the `copywrite` was updated in a point that is not working properly with our project. It did remove the end_year option, and now is incorrectlying adding the headers like:

<img width="441" height="210" alt="Screenshot 2026-03-27 at 12 01 25" src="https://github.com/user-attachments/assets/8b6cc2de-7431-4f55-9be4-4512c0ef4f64" />

Breaking the pipeline and not giving us configuration options to ignore that.

So my PR does three things:

- Pin the `copywrite` version to the last working version in our repo (0.24.2)
- Update checkout to v6 + SHA-pin it
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to `setup-copywrite` as the action didn't update to Node24. It's still giving warnings, but they are going to disappear in June when Node JS upgrades in actions are going to be mandatory on GitHub.