### PR TITLE
release: v0.6.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         run: npm run package -- --githubBranch $GITHUB_REF_NAME --pre-release --target=${{ matrix.vsce_target }}
 
       - name: Package Stable VSIX
-        if: github.event_name == 'release' || inputs.deploy_type == 'stable'
+        if: inputs.deploy_type != 'prerelease'
         run: npm run package -- --target=${{ matrix.vsce_target }}
 
       - name: Upload vsix as artifact
@@ -99,6 +99,7 @@ jobs:
         with:
           name: ${{ matrix.vsce_target }}
           path: '*.vsix'
+          if-no-files-found: error
 
   publish-pre-marketplace:
     name: Publish Prerelease to Marketplace
@@ -116,7 +117,7 @@ jobs:
     name: Publish Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: (github.event_name == 'release' || inputs.deploy_type == 'stable') && needs.build.result == 'success'
+    if: inputs.deploy_type != 'prerelease' && needs.build.result == 'success'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
       - name: Publish Stable to Marketplace
@@ -128,7 +129,7 @@ jobs:
     name: Publish OpenVSX
     runs-on: ubuntu-latest
     needs: build
-    if: (github.event_name == 'release' || inputs.deploy_type == 'stable') && needs.build.result == 'success'
+    if: inputs.deploy_type != 'prerelease' && needs.build.result == 'success'
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
       - name: Publish Stable to OpenVSX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.6.2 (2026-05-06)
+
+This Github release doesn't add any new user-facing code, but the publishing
+of the VSCode extension will include the code that was supposed to be released
+on 0.6.1, but it wasn't published due to problems on the pipeline.
+
+**Full Changelog**: https://github.com/opentofu/vscode-opentofu/compare/v0.6.1...v0.6.2
+
 ## v0.6.1 (2026-04-28)
 
 *Includes a new LS version - [tofu-ls 0.4.1](https://github.com/opentofu/tofu-ls/releases/tag/v0.4.1):*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.6.2 (2026-05-06)
 
-This Github release doesn't add any new user-facing code, but the publishing
-of the VSCode extension will include the code that was supposed to be released
-on 0.6.1, but it wasn't published due to problems on the pipeline.
+This GitHub release doesn't add any new user-facing features. However,
+publishing the VS Code extension will include the code that was supposed to
+be released in version 0.6.1 but wasn’t published due to pipeline issues.
 
 **Full Changelog**: https://github.com/opentofu/vscode-opentofu/compare/v0.6.1...v0.6.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-opentofu",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-opentofu",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@zodios/core": "10.9.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-opentofu",
   "displayName": "OpenTofu (official)",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,


### PR DESCRIPTION
This PR does the following:

- Adds `if-no-files-found` to the upload artifact step to produce a clear error when no files are found.
- Adds a manual entry for 0.6.2 to the CHANGELOG.
- Removes one of the event types so manual use of `release.yml` still releases properly. 
- Bumps the vscode-opentofu project to 0.6.2 so GitHub Releases and the VSCode Extension can be published.