### PR TITLE
Prep for 0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3 (2026-07-08)
+
+- Includes a new LS version - [tofu-ls 0.5.3](https://github.com/opentofu/tofu-ls/releases/tag/v0.5.3):\*
+
 ## v0.6.2 (2026-05-06)
 
 This GitHub release doesn't add any new user-facing features. However,
@@ -10,60 +14,70 @@ be released in version 0.6.1 but wasn’t published due to pipeline issues.
 
 ## v0.6.1 (2026-04-28)
 
-*Includes a new LS version - [tofu-ls 0.4.1](https://github.com/opentofu/tofu-ls/releases/tag/v0.4.1):*
-* Fixes the way semantic tokens are handled
+_Includes a new LS version - [tofu-ls 0.4.1](https://github.com/opentofu/tofu-ls/releases/tag/v0.4.1):_
+
+- Fixes the way semantic tokens are handled
 
 **Full Changelog**: https://github.com/opentofu/vscode-opentofu/compare/v0.6.0...v0.6.1
 
 ## v0.6.0 (2025-12-11)
 
-*Includes a new LS version - [tofu-ls 0.3.1](https://github.com/opentofu/tofu-ls/releases/tag/v0.3.1)*
-    
+_Includes a new LS version - [tofu-ls 0.3.1](https://github.com/opentofu/tofu-ls/releases/tag/v0.3.1)_
+
 ### Other Changes
-* Clarifying binary settings by @diofeher in https://github.com/opentofu/vscode-opentofu/pull/108
-* Add release support for alpine architectures by @diofeher in https://github.com/opentofu/vscode-opentofu/pull/109
+
+- Clarifying binary settings by @diofeher in https://github.com/opentofu/vscode-opentofu/pull/108
+- Add release support for alpine architectures by @diofeher in https://github.com/opentofu/vscode-opentofu/pull/109
 
 **Full Changelog**: https://github.com/opentofu/vscode-opentofu/compare/v0.5.0...v0.6.0
 
-
 ## v0.5.0 (2025-10-31)
 
-*Includes a new LS version - [tofu-ls latest](https://github.com/opentofu/tofu-ls/releases/tag/vlatest)*
+_Includes a new LS version - [tofu-ls latest](https://github.com/opentofu/tofu-ls/releases/tag/vlatest)_
 
 ### Features
-* Ephemeral block and attribute support
+
+- Ephemeral block and attribute support
 
 **Full Changelog**: https://github.com/opentofu/vscode-opentofu/compare/v0.4.2...v0.5.0
 
 ## 0.4.1 (2025-09-16)
+
 - Fix: language server crashing on resources with no provider prefix
 - Fix: Removes the `fallback` attribute from the fallback block
 - Fix: Adds pseudo-recursive fallback blocks for encryption
 - Internal: Dependency updates for security
 
 ## 0.4.0 (2025-09-11)
-- Adds documentation links for `data_source` resources. 
+
+- Adds documentation links for `data_source` resources.
 
 ## 0.3.5 (2025-08-15)
+
 - Adds the `dynamic` block support inside the `provider` blocks.
 
 ## 0.3.4 (2025-07-07)
+
 - Adding references to complex object variables
 
 ## 0.3.3 (2025-06-26)
+
 - Matching `removed` block schema to OpenTofu implementation
 - Adding references to provider for each on LSP
 - Integration tests for encryption and resource provider for-each block
 - Fixing a bug when passing `tofu` binary options
 
 ## 0.3.2 (2025-06-20)
+
 - `encryption` block key providers now support all available options
 
 ## 0.3.1 (2025-06-19)
+
 - displayName change to "OpenTofu (official)"
 - Fixes LS binary options, "opentofu" -> "tofu"
 
 ## 0.3.0 (2025-06-19)
+
 - Support for `encryption` block
 - Support for provider `for_each`
 - Documentation updates

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.4.1"
+    "version": "0.5.3"
   },
   "syntax": {
     "version": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-opentofu",
   "displayName": "OpenTofu (official)",
   "description": "Syntax highlighting and autocompletion for OpenTofu",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "opentofu",
   "license": "MPL-2.0",
   "preview": false,
@@ -17,7 +17,7 @@
     "vscode": "^1.88.0"
   },
   "langServer": {
-    "version": "0.5.3"
+    "version": "0.4.1"
   },
   "syntax": {
     "version": "0.7.0"


### PR DESCRIPTION
This bumps versions, and also formats the changelog.md to keep it consistent.